### PR TITLE
Option to display all possible facets when user first clicks on the search box.

### DIFF
--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -47,7 +47,7 @@ VS.ui.SearchInput = Backbone.View.extend({
   // See `addTextFacetRemainder` for explanation on how the remainder works.
   setupAutocomplete : function() {
     this.box.autocomplete({
-      minLength : 1,
+      minLength : 0,
       delay     : 50,
       autoFocus : true,
       position  : {offset : "0 -1"},
@@ -81,14 +81,18 @@ VS.ui.SearchInput = Backbone.View.extend({
   // first letter of any word in matches, and finally sorted according to the
   // value's own category.
   autocompleteValues : function(req, resp) {
-    var searchTerm = req.term;
-    var lastWord   = searchTerm.match(/\w+$/); // Autocomplete only last word.
-    var re         = VS.utils.inflector.escapeRegExp(lastWord && lastWord[0] || ' ');
-    var prefixes   = VS.options.callbacks.facetMatches() || [];
+    var searchTerm   = req.term;
+    var lastWord     = searchTerm.match(/\w+$/); // Autocomplete only last word.
+    var re           = VS.utils.inflector.escapeRegExp(lastWord && lastWord[0] || ' ');
+    var prefixes     = VS.options.callbacks.facetMatches() || [];
+    var tutorEnabled = VS.options.facetTutor && VS.app.searchBox.getQuery() == '' &&
+                         VS.app.searchBox.inputViews.length == 1;
 
-    // Only match from the beginning of the word.
+    // Only match from the beginning of the word. If facetTutor is enabled and
+    // the search box is blank, accept all prefixes to render a list of all facets.
     var matcher    = new RegExp('^' + re, 'i');
     var matches    = $.grep(prefixes, function(item) {
+      if (tutorEnabled) return true;
       return item && matcher.test(item.label || item);
     });
 
@@ -144,7 +148,8 @@ VS.ui.SearchInput = Backbone.View.extend({
   addTextFacetRemainder : function(facetValue) {
     var boxValue = this.box.val();
     var lastWord = boxValue.match(/\b(\w+)$/);
-    var matcher = new RegExp(lastWord[0], "i");
+    var re       = VS.utils.inflector.escapeRegExp(lastWord && lastWord[0] || ' ');
+    var matcher = new RegExp('^' + re, 'i');
     if (lastWord && facetValue.search(matcher) == 0) {
       boxValue = boxValue.replace(/\b(\w+)$/, '');
     }


### PR DESCRIPTION
If "facetTutor: true" is specified in the global options, then the facet autocomplete will match on 0 characters, causing the drop down to render every facet option. This an alternative to a "Try searching for: [facets]" to help users figure out how to use them.

Essentially reverts back to match on 1+ characters if a partial query is already present (otherwise it's just obnoxious).
