### PR TITLE
Visualsearch users should be able to opt out of autocomplete sorting

### DIFF
--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -132,7 +132,10 @@ VS.ui.SearchFacet = Backbone.View.extend({
     var value    = this.model.get('value');
     var searchTerm = req.term;
 
-    this.options.app.options.callbacks.valueMatches(category, searchTerm, function(matches) {
+    this.options.app.options.callbacks.valueMatches(category, searchTerm, function(matches, preserveOrder) {
+      if (preserveOrder) {
+        resp(matches);
+      }
       matches = matches || [];
       if (searchTerm && value != searchTerm) {
         var re = VS.utils.inflector.escapeRegExp(searchTerm || '');

--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -85,8 +85,11 @@ VS.ui.SearchInput = Backbone.View.extend({
     var searchTerm = req.term;
     var lastWord   = searchTerm.match(/\w+$/); // Autocomplete only last word.
     var re         = VS.utils.inflector.escapeRegExp(lastWord && lastWord[0] || ' ');
-    this.app.options.callbacks.facetMatches(function(prefixes) {
+    this.app.options.callbacks.facetMatches(function(prefixes, preserveOrder) {
       prefixes = prefixes || [];
+      if (preserveOrder) {
+          resp(prefixes);
+      }
       // Only match from the beginning of the word.
       var matcher    = new RegExp('^' + re, 'i');
       var matches    = $.grep(prefixes, function(item) {


### PR DESCRIPTION
When using the Visualsearch callbacks for facets and autocompletion, the server might have sent down the suggestions in a better order than the grepping/sorting that the javascript does. This PR adds another parameter to the valueMatches and facetMatches callbacks that allows them to opt out of the filtering/sorting step.
