### PR TITLE
Don't try to trim anything other than strings

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -224,6 +224,12 @@
                 case 'filter':
                   callback(['published', 'unpublished', 'draft']);
                   break;
+                case 'number':
+                  callback([
+                    { value: 100,  label: 'Hundred' },
+                    { value: 1000,  label: 'Thousand' }
+                  ]);
+                  break;
                 case 'access':
                   callback(['public', 'private', 'protected']);
                   break;
@@ -299,7 +305,7 @@
             },
             facetMatches : function(callback) {
               callback([
-                'account', 'filter', 'access', 'title',
+                'account', 'filter', 'access', 'title', 'number',
                 { label: 'city',    category: 'location' },
                 { label: 'address', category: 'location' },
                 { label: 'country', category: 'location' },
@@ -358,6 +364,12 @@
                   break;
                 case 'filter':
                   callback(['published', 'unpublished', 'draft']);
+                  break;
+                case 'number':
+                  callback([
+                    { value: 100,  label: 'Hundred' },
+                    { value: 1000,  label: 'Thousand' }
+                  ]);
                   break;
                 case 'access':
                   callback(['public', 'private', 'protected']);
@@ -434,7 +446,7 @@
             },
             facetMatches : function(callback) {
               callback([
-                'account', 'filter', 'access', 'title',
+                'account', 'filter', 'access', 'title', 'number',
                 { label: 'city',    category: 'location' },
                 { label: 'address', category: 'location' },
                 { label: 'country', category: 'location' },

--- a/lib/js/utils/inflector.js
+++ b/lib/js/utils/inflector.js
@@ -8,6 +8,7 @@ VS.utils.inflector = {
 
   // Delegate to the ECMA5 String.prototype.trim function, if available.
   trim : function(s) {
+    if (!_.isString(s)) { return s }
     return s.trim ? s.trim() : s.replace(/^\s+|\s+$/g, '');
   },
   


### PR DESCRIPTION
Ran into a minor problem when I tried to use numeric IDs as the value for a facet:

`Uncaught TypeError: Object 100 has no method 'replace'`

Fixed it here, I think.
