### PR TITLE
I added a new options flag: autosearch

### DIFF
--- a/build/visualsearch.js
+++ b/build/visualsearch.js
@@ -30,6 +30,7 @@
     var defaults = {
       container   : '',
       query       : '',
+      autosearch  : true,
       unquotable  : [],
       callbacks   : {
         search          : $.noop,
@@ -550,7 +551,9 @@ VS.ui.SearchFacet = Backbone.View.extend({
         var originalValue = this.model.get('value');
         this.set(ui.item.value);
         if (originalValue != ui.item.value || this.box.val() != ui.item.value) {
-          this.search(e);
+            if (this.options.app.options.autosearch) {
+                this.search(e);
+            }
         }
         return false;
       }, this),

--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -79,7 +79,9 @@ VS.ui.SearchFacet = Backbone.View.extend({
         var originalValue = this.model.get('value');
         this.set(ui.item.value);
         if (originalValue != ui.item.value || this.box.val() != ui.item.value) {
-          this.search(e);
+          if (this.options.app.options.autosearch) {
+            this.search(e);
+          }
         }
         return false;
       }, this),

--- a/lib/js/visualsearch.js
+++ b/lib/js/visualsearch.js
@@ -30,6 +30,7 @@
     var defaults = {
       container   : '',
       query       : '',
+      autosearch  : true,
       unquotable  : [],
       callbacks   : {
         search          : $.noop,


### PR DESCRIPTION
I added this option and defaulted it to true so that all of your functionality still exists.  Users have the option to turn off the feature that automatically searches, and waits for them to hit enter before doing so.

I had a comment left on my blog asking me to submit this as a pull request.

... Only searches after hitting enter.
