### PR TITLE
Add an option to prevent matching the returned values in valueMatches

### DIFF
--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -152,13 +152,17 @@ VS.ui.SearchFacet = Backbone.View.extend({
       matches = matches || [];
       
       if (searchTerm && value != searchTerm) {
-        var re = VS.utils.inflector.escapeRegExp(searchTerm || '');
-        var matcher = new RegExp('\\b' + re, 'i');
-        matches = $.grep(matches, function(item) {
-          return matcher.test(item) ||
-                 matcher.test(item.value) ||
-                 matcher.test(item.label);
+        if(options.preserveMatches) {
+          return matches;
+        } else {
+          var re = VS.utils.inflector.escapeRegExp(searchTerm || '');
+          var matcher = new RegExp('\\b' + re, 'i');
+          matches = $.grep(matches, function(item) {
+            return matcher.test(item) ||
+                   matcher.test(item.value) ||
+                   matcher.test(item.label);
         });
+        }
       }
       
       if (options.preserveOrder) {


### PR DESCRIPTION
My server is returning only the subset of values that match the search term. Furthermore, I want the match to occur on more that just the begining of the work (matches anywhere). So I don't want the callback to filter the matches for me.

This change allows passing an 'preserveMatches' option to the valueMatches callback. It prevents the callback from filtering the matches.
