### PR TITLE
Improvements & fixes to search_parser

### DIFF
--- a/lib/js/utils/search_parser.js
+++ b/lib/js/utils/search_parser.js
@@ -3,8 +3,8 @@
 var $ = jQuery; // Handle namespaced jQuery
 
 // Used to extract keywords and facets from the free text search.
-var FREETEXT_RE = '(\'.+?\'|".+?"|[^\'"\\s]\\S*)';
-var CATEGORY_RE = FREETEXT_RE +                ':\\s*';
+var FREETEXT_RE = '(\'[^\']+\'|"[^"]+"|[^\'"\\s]\\S*)';
+var CATEGORY_RE = FREETEXT_RE +                     ':\\s*';
 VS.app.SearchParser = {
 
   // Matches `category: "free text"`, with and without quotes.


### PR DESCRIPTION
- Extracted regular expressions to avoid redundancies
- Allowed unquoted 1-character categories (quoted ones worked, but it would not correctly round-trip and unquoted parsing wouldn't work at all)
- Improved parsing of freetext before/around categories
