### PR TITLE
Handle programmatic alterations of searchQuery (the facets collection)

### DIFF
--- a/lib/js/views/search_box.js
+++ b/lib/js/views/search_box.js
@@ -24,8 +24,12 @@ VS.ui.SearchBox = Backbone.View.extend({
     this.facetViews = [];
     this.inputViews = [];
     _.bindAll(this, 'renderFacets', '_maybeDisableFacets', 'disableFacets',
-              'deselectAllFacets');
-    this.app.searchQuery.bind('reset', this.renderFacets);
+              'deselectAllFacets', 'addedFacet', 'removedFacet', 'changedFacet');
+    this.app.searchQuery
+            .bind('reset', this.renderFacets)
+            .bind('add', this.addedFacet)
+            .bind('remove', this.removedFacet)
+            .bind('change', this.changedFacet);
     $(document).bind('keydown', this._maybeDisableFacets);
   },
 
@@ -96,12 +100,15 @@ VS.ui.SearchBox = Backbone.View.extend({
     initialQuery = VS.utils.inflector.trim(initialQuery || '');
     if (!category) return;
 
-    var model = new VS.model.SearchFacet({
+    this.app.searchQuery.add(new VS.model.SearchFacet({
       category : category,
       value    : initialQuery || '',
       app      : this.app
-    });
-    this.app.searchQuery.add(model, {at: position});
+    }), {at: position});
+  },
+
+  // Renders a newly added facet, and selects it
+  addedFacet : function (model) {
     this.renderFacets();
     var facetView = _.detect(this.facetViews, function(view) {
       if (view.model == model) return true;
@@ -110,6 +117,17 @@ VS.ui.SearchBox = Backbone.View.extend({
     _.defer(function() {
       facetView.enableEdit();
     });
+  },
+
+  changedFacet: function () {
+    this.renderFacets();
+  },
+
+  // Re-renders facets and selects the nearest input field from the removed facet
+  removedFacet : function (facet, query, options) {
+    var facetView = this.facetViews[options.index];
+    this.renderFacets();
+    this.focusNextFacet(facetView, -1, {viewPosition: facetView.options.order});
   },
 
   // Renders each facet as a searchFacet view.

--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -324,16 +324,9 @@ VS.ui.SearchFacet = Backbone.View.extend({
 
   // Deletes the facet and sends the cursor over to the nearest input field.
   remove : function(e) {
-    var committed = this.model.get('value');
     this.deselectFacet();
     this.disableEdit();
     this.options.app.searchQuery.remove(this.model);
-    if (committed) {
-      this.search(e, -1);
-    } else {
-      this.options.app.searchBox.renderFacets();
-      this.options.app.searchBox.focusNextFacet(this, -1, {viewPosition: this.options.order});
-    }
   },
 
   // Selects the text in the facet's input field. When the user tabs between


### PR DESCRIPTION
Adds a bunch of event handlers on `searchQuery` from the searchbox (add, remove and change on top of the preexisting reset).
- (re)moves a few lines from the search_facet view
- allows code outside of VS to change the value of existing facets and to add facets to (and remove facets from) the `searchQuery` collection, making it much simpler to programmatically alter the list of facets. It's also very useful to attach application-specific metadata to facets, which the rest of the application (generally the part handling the search itself) uses for special behavior.
