### PR TITLE
Pluggable SearchFacet views

### DIFF
--- a/lib/js/views/search_box.js
+++ b/lib/js/views/search_box.js
@@ -148,7 +148,7 @@ VS.ui.SearchBox = Backbone.View.extend({
 
   // Render a single facet, using its category and query value.
   renderFacet : function(facet, position) {
-    var view = new VS.ui.SearchFacet({
+    var view = new (this.app.options.callbacks.make_facet)({
       app   : this.app,
       model : facet,
       order : position

--- a/lib/js/visualsearch.js
+++ b/lib/js/visualsearch.js
@@ -36,7 +36,8 @@
         focus           : $.noop,
         blur            : $.noop,
         facetMatches    : $.noop,
-        valueMatches    : $.noop
+        valueMatches    : $.noop,
+        make_facet      : VS.ui.SearchFacet
       }
     };
     this.options           = _.extend({}, defaults, options);


### PR DESCRIPTION
Currently, VisualSearch will always instantiate a `VS.ui.SearchFacet` when rendering a facet model.

On a project I'm working on, I need some facets (inserted programmatically, see pull request 49) to have slightly special renderings or behaviors.

To that end, I simply added a `make_facet` callback option which defaults to `VS.ui.SearchFacet` and should return some sort of `VS.ui.SearchFacet`-like backbone view. Because JS constructors will use an explicitly returned value if any, `make_facet` can be a simple function as long as all code paths return a view instance.
