### PR TITLE
Unneeded indirection via anonymous function in SearchBox#renderFacets

### DIFF
--- a/lib/js/views/search_box.js
+++ b/lib/js/views/search_box.js
@@ -138,9 +138,7 @@ VS.ui.SearchBox = Backbone.View.extend({
 
     this.$('.VS-search-inner').empty();
 
-    this.app.searchQuery.each(_.bind(function(facet, i) {
-      this.renderFacet(facet, i);
-    }, this));
+    this.app.searchQuery.each(_.bind(this.renderFacet, this));
 
     // Add on an n+1 empty search input on the very end.
     this.renderSearchInput();


### PR DESCRIPTION
An even shorter alternative would be jQuery's `$.proxy(this, 'renderFacet')` which avoids repeating `this`
