### PR TITLE
Updated VS.model.SearchQuery.find()

### DIFF
--- a/lib/js/models/search_query.js
+++ b/lib/js/models/search_query.js
@@ -28,7 +28,7 @@ VS.model.SearchQuery = Backbone.Collection.extend({
     var facet = this.detect(function(facet) {
       return facet.get('category') == category;
     });
-    return facet && facet.get('value');
+    return facet;
   },
 
   // Counts the number of times a specific category is in the search query.


### PR DESCRIPTION
Changes `VS.model.SearchQuery.find()` to return the facet object or undefined.

Previously it would return the value of the facet.  It seems that a collection `find()` method should return a model instance (if found).  This method isn't called anywhere else, so the change should allow easier programmatic access to facets in the `searchQuery` collection without introducing errors.
