### PR TITLE
Added Delete key functionality

### DIFF
--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -402,6 +402,11 @@ VS.ui.SearchFacet = Backbone.View.extend({
         e.preventDefault();
         this.selectFacet();
       }
+    } else if (key == 'delete') {
+      if (this.modes.selected == 'is') {
+        e.preventDefault();
+        this.remove(e);
+      }
     }
 
     this.resize(e);

--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -370,6 +370,10 @@ VS.ui.SearchInput = Backbone.View.extend({
         this.app.searchBox.focusNextFacet(this, -1, {backspace: true});
         return false;
       }
+    } else if (key == 'delete' && !this.app.searchBox.allSelected()) {
+      e.preventDefault();
+      this.app.searchBox.focusNextFacet(this, 1, {selectFacet: true});
+      return false;
     }
 
     this.box.trigger('resize.autogrow', e);


### PR DESCRIPTION
When cursor is between two facets, pressing delete once will select the facet to the right.  Pressing delete again will remove the facet.

Change makes visualsearch behave as expected when delete key is pressed, and makes the control feel more natural.
