### PR TITLE
Added handling for Home and End keys

### DIFF
--- a/lib/js/utils/hotkeys.js
+++ b/lib/js/utils/hotkeys.js
@@ -25,6 +25,8 @@ VS.app.hotkeys = {
     '40':  'downArrow',
     '46':  'delete',
     '8':   'backspace',
+    '35':  'end',
+    '36':  'home',
     '9':   'tab',
     '188': 'comma'
   },

--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -370,6 +370,12 @@ VS.ui.SearchInput = Backbone.View.extend({
         this.app.searchBox.focusNextFacet(this, -1, {backspace: true});
         return false;
       }
+    } else if (key == 'end') {
+      var view = this.app.searchBox.inputViews[this.app.searchBox.inputViews.length-1];
+      view.setCursorAtEnd(-1);
+    } else if (key == 'home') {
+      var view = this.app.searchBox.inputViews[0];
+      view.setCursorAtEnd(-1);
     }
 
     this.box.trigger('resize.autogrow', e);


### PR DESCRIPTION
When focus is not in an input, home and end will now position the cursor at the expected position within the search box.

Change makes visualsearch box feel more natural and behave as expected.  
