### PR TITLE
Removed bug with option "preserveMatches"

### DIFF
--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -155,7 +155,7 @@ VS.ui.SearchFacet = Backbone.View.extend({
       
       if (searchTerm && value != searchTerm) {
         if (options.preserveMatches) {
-          return matches;
+          resp(matches);
         } else {
           var re = VS.utils.inflector.escapeRegExp(searchTerm || '');
           var matcher = new RegExp('\\b' + re, 'i');


### PR DESCRIPTION
The autocomplete does not open if the option "preserveMatches" is set to true.
