### PR TITLE
Selecting a facet name with spaces from the autocomplete menu causes the creation of an additional facet

### DIFF
--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -53,6 +53,8 @@ VS.ui.SearchInput = Backbone.View.extend({
       autoFocus : true,
       position  : {offset : "0 -1"},
       source    : _.bind(this.autocompleteValues, this),
+      // Prevent changing the input value on focus of an option
+      focus     : function() { return false; },
       create    : _.bind(function(e, ui) {
         $(this.el).find('.ui-autocomplete-input').css('z-index','auto');
       }, this),


### PR DESCRIPTION
A GIF is worth a thousand words:

![GitHub Logo](http://i.imgur.com/rzMyshb.gif)

How to reproduce:
1. Populate the facets autocomplete menu with at least one name containing spaces (e.g. "U.S. State").
2. Using the keyboard (this is important, the bug doesn't trigger when selecting the facet using the mouse) select the facet with spaces and press tab or enter.
3. The result will be the facet you selected plus an additional "remainder facet" containing the selected facet's name.

This seems to happen only when the autocomplete menu changes the input box's value while "browsing" options. The fix simply prevents that behavior, keeping the input box unaltered unless the user types something in manually.

Hope you find this useful, and thanks for the great widget!
