### PR TITLE
Remove the remainder based on the optional label value.

### DIFF
--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -60,7 +60,7 @@ VS.ui.SearchInput = Backbone.View.extend({
         e.preventDefault();
         // stopPropogation does weird things in jquery-ui 1.9
         // e.stopPropagation();
-        var remainder = this.addTextFacetRemainder(ui.item.value);
+        var remainder = this.addTextFacetRemainder(ui.item.label || ui.item.value);
         var position  = this.options.position + (remainder ? 1 : 0);
         this.app.searchBox.addFacet(ui.item instanceof String ? ui.item : ui.item.value, '', position);
         return false;


### PR DESCRIPTION
If a facet-value is given, the autocompletion failed to calculate the remainder based on the label, since the label is what the user sees while typing.

Testcase, change:

```
facetMatches : function(callback) {
  callback([
    'account', 'filter', 'access', 'title',
    { label: 'city',    category: 'location' },
    { label: 'address', category: 'location' },
    { label: 'country', category: 'location' },
    { label: 'state',   category: 'location' },
  ]);
}
```

to 

```
facetMatches : function(callback) {
  callback([
    'account', 'filter', 'access', 'title',
    { label: 'city',    category: 'location' },
    { label: 'address', category: 'location' },
    { label: 'country', category: 'location' },
    { label: 'state',  "value":"loc.state", category: 'location' },
  ]);
}
```

and type "sta" (the state-facet should be autocompleted) and press enter.

Expected behaviour: Search query should be "loc.state:"
Result: Search query is: "text: sta loc.state:"
