### PR TITLE
Feature handle copypaste

### DIFF
--- a/build/visualsearch.js
+++ b/build/visualsearch.js
@@ -1563,7 +1563,7 @@ $.fn.extend({
 
         $tester.html(value);
 
-        $input.width($tester.width() + 3 + parseInt($input.css('min-width')));
+        $input.width($tester.get(0).scrollWidth);
         $input.trigger('updated.autogrow');
       });
 


### PR DESCRIPTION
Bug when a text is pasted into the <input> : the value catched by the event is the previous one, so the size is not the good one.
