### PR TITLE
Options on views for new bb version

### DIFF
--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -53,6 +53,8 @@ VS.ui.SearchInput = Backbone.View.extend({
       autoFocus : true,
       position  : {offset : "0 -1"},
       source    : _.bind(this.autocompleteValues, this),
+      // Prevent changing the input value on focus of an option
+      focus     : function() { return false; },
       create    : _.bind(function(e, ui) {
         $(this.el).find('.ui-autocomplete-input').css('z-index','auto');
       }, this),


### PR DESCRIPTION
Fix https://github.com/documentcloud/visualsearch/issues/112 

On newer backbone version VS code dont work beacuse the new way options on views are used.
You can check bb discuss about here https://github.com/jashkenas/backbone/pull/2461
