### PR TITLE
options on views for new bb version

### DIFF
--- a/lib/js/views/search_box.js
+++ b/lib/js/views/search_box.js
@@ -16,7 +16,10 @@ VS.ui.SearchBox = Backbone.View.extend({
 
   // Creating a new SearchBox registers handlers for re-rendering facets when necessary,
   // as well as handling typing when a facet is selected.
-  initialize : function() {
+  initialize : function(options) {
+    if(options)
+      this.options = options;
+
     this.app = this.options.app;
     this.flags = {
       allSelected : false

--- a/lib/js/views/search_facet.js
+++ b/lib/js/views/search_facet.js
@@ -20,6 +20,9 @@ VS.ui.SearchFacet = Backbone.View.extend({
   },
 
   initialize : function(options) {
+    if(options)
+      this.options = options;
+
     this.flags = {
       canClose : false
     };

--- a/lib/js/views/search_input.js
+++ b/lib/js/views/search_input.js
@@ -17,7 +17,10 @@ VS.ui.SearchInput = Backbone.View.extend({
     'dblclick input'  : 'startTripleClickTimer'
   },
 
-  initialize : function() {
+  initialize : function(options) {
+    if(options)
+      this.options = options;
+
     this.app = this.options.app;
     this.flags = {
       canClose : false


### PR DESCRIPTION
Fix https://github.com/documentcloud/visualsearch/issues/112 

On newer backbone version VS code dont work beacuse the new way options on views are used.
You can check bb discuss about here https://github.com/jashkenas/backbone/pull/2461
