### PR TITLE
adding bower file for visualsearch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "visualsearch",
+  "version": "0.4.0",
+  "homepage": "http://documentcloud.github.io/visualsearch/",
+  "authors": [
+    "Samuel Clay"
+    "@samuelclay"
+  ],
+  "description": "A Rich Search Box for Real Data",
+  "main": ["build-min/visualsearch-datauri.css", "build-min/visualsearch.css", "build-min/visualsearch.js"],
+  "license": "MIT",
+  "dependencies": {
+    "jQuery": ">=1.4",
+    "jquery-ui": ">=1.8",
+    "backbone": "0.9.10",
+    "underscore":"1.4.3"
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "Rakefile",
+    "vendor",
+    "*.html",
+    "build",
+    "docs",
+    "*.yml"
+  ]
+}


### PR DESCRIPTION
A bower.json file for use with yeoman projects, etc.

To register in the bower package directory, simply run:

`bower register <my-package-name> <git-endpoint>`

e.g. (if you accept the pull request ;-):
`bower register visualsearch https://github.com/documentcloud/visualsearch.git`
