### PR TITLE
jQuery to jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
   "main": ["build-min/visualsearch-datauri.css", "build-min/visualsearch.css", "build-min/visualsearch.js"],
   "license": "MIT",
   "dependencies": {
-    "jQuery": ">=1.4",
+    "jquery": ">=1.4",
     "jquery-ui": ">=1.8",
     "backbone": ">=0.9.10",
     "underscore":">=1.4.3"


### PR DESCRIPTION
jQuery is treated differently from the lowercase version by bower, so installing visualsearch with other package that include the lowercase version of jquery will mess up the internal registry. Changing to the lowercase version to stop bower from doing weird stuff.
