### PR TITLE
Update README - Fix documentation URL

### DIFF
--- a/README
+++ b/README
@@ -13,4 +13,4 @@ completable values for any facet. You can retrieve the search query as a
 structured object, so you don't have to parse the query string yourself.
 
 For documentation, pre-packed downloads, demos, and tests, see:
-http://documentcloud.github.com/visualsearch
+https://documentcloud.github.io/visualsearch/


### PR DESCRIPTION
Changing the document link from a broken URL referencing a `github.com` domain, to a working one, using the newer `github.io` domain, `https://documentcloud.github.io/visualsearch/`.